### PR TITLE
Update gradle cache repo name

### DIFF
--- a/aql/wpilib-generic-gradle-cache_unused.aql
+++ b/aql/wpilib-generic-gradle-cache_unused.aql
@@ -3,7 +3,7 @@
     {
       "aql": {
         "items.find": {
-          "repo": "wpilib-generic-gradle-cache",
+          "repo": "wpilib-generic-gradlecache",
           "$or":[
             {
                 "stat.downloaded": { "$before":"1mo" }


### PR DESCRIPTION
Artifactory now does not allow repos that end in -cache. Update virtual repo naming to track this new limitation